### PR TITLE
Add docs governance gate and ADR discussion checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,13 @@ V1 stores signals without using them in ranking; V2 integrates them into PageRan
 4. **Zero-mock testing**: Test against real services where possible.
    Use D1 local bindings or Miniflare for Cloudflare Workers testing.
 5. **DRY principle**: Every piece of knowledge has a single, authoritative representation.
+6. **Discussion-first ADR flow**: Every ADR must include
+   `> Discussion: [discussion log](xxx.discussion.md)`.
+7. **Governance gate**: Before handoff/merge, run `pnpm doc:governance` and keep it passing.
 
 ## Architecture Overview
 
-```
+```text
 ┌──────────────────────────────────────────────────────┐
 │  CF Worker — SkillRank Engine                        │
 │                                                      │
@@ -58,7 +61,7 @@ V1 stores signals without using them in ranking; V2 integrates them into PageRan
 ## Reference Sub-Documents
 
 | Document | Path | When to read |
-|----------|------|--------------|
+| --- | --- | --- |
 | Architecture details | `doc/agents/architecture.md` | Deep-dive into module design, data flow |
 | Known issues | `doc/agents/known-issues.md` | Debugging, workarounds, open items |
 | DX Tooling | `doc/agents/dx-tooling.md` | Skills, commands, doc governance |
@@ -79,4 +82,6 @@ pnpm dev                        # Local dev (wrangler dev)
 pnpm test                       # Run tests (vitest)
 pnpm deploy                     # Deploy to CF Workers
 npx tsx scripts/generate-doc-index.ts all  # Regenerate doc indexes
+pnpm doc:check                  # Validate ADR metadata + discussion links + index markers
+pnpm doc:governance             # gen:index + doc:check
 ```

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -9,7 +9,7 @@ create a new ADR that supersedes the original.
 
 <!-- INDEX:START -->
 | ADR | Title | Status | Date |
-|-----|-------|--------|------|
+| --- | --- | --- | --- |
 | 001 | [Hub-as-Domain PageRank Model](001-hub-as-domain-pagerank-model.md) | Proposed | 2026-02-28 |
 | 002 | [D1 Database Schema Design](002-d1-schema-design.md) | Proposed | 2026-02-28 |
 <!-- INDEX:END -->
@@ -27,6 +27,8 @@ To create a new ADR:
 
 Status: Proposed
 Date: YYYY-MM-DD
+
+> Discussion: [discussion log](NNN-topic.discussion.md)
 
 ## Context
 

--- a/doc/pitfall/README.md
+++ b/doc/pitfall/README.md
@@ -7,7 +7,7 @@ encountered during SkillRank development.
 
 <!-- INDEX:START -->
 | ID | Title | Area | Severity | Status |
-|----|-------|------|----------|--------|
+| --- | --- | --- | --- | --- |
 <!-- INDEX:END -->
 
 ## Deferred

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "deploy": "wrangler deploy",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "generate-index": "tsx scripts/generate-doc-index.ts all"
+    "generate-index": "tsx scripts/generate-doc-index.ts all",
+    "gen:index": "tsx scripts/generate-doc-index.ts all",
+    "doc:check": "tsx scripts/verify-doc-governance.ts",
+    "doc:governance": "pnpm gen:index && pnpm doc:check"
   },
   "devDependencies": {
     "typescript": "^5.7.0",
@@ -16,5 +19,6 @@
     "wrangler": "^4.0.0",
     "tsx": "^4.0.0",
     "@cloudflare/workers-types": "^4.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
 }

--- a/scripts/generate-doc-index.ts
+++ b/scripts/generate-doc-index.ts
@@ -104,7 +104,7 @@ function generateAdrTable(entries: AdrEntry[]): string {
   );
   return [
     '| ADR | Title | Status | Date |',
-    '|-----|-------|--------|------|',
+    '| --- | --- | --- | --- |',
     ...rows,
   ].join('\n');
 }
@@ -117,7 +117,7 @@ function generatePitfallTable(entries: PitEntry[]): string {
   );
   return [
     '| ID | Title | Area | Severity | Status |',
-    '|----|-------|------|----------|--------|',
+    '| --- | --- | --- | --- | --- |',
     ...rows,
   ].join('\n');
 }
@@ -162,7 +162,7 @@ function injectIndex(readmePath: string, table: string): void {
 function processAdr(): void {
   const dir = join(DOC_ROOT, 'adr');
   const files = readdirSync(dir)
-    .filter((f) => /^\d{3}-.*\.md$/.test(f))
+    .filter((f) => /^\d{3}-.*\.md$/.test(f) && !f.endsWith('.discussion.md'))
     .map((f) => join(dir, f));
 
   const entries = files.map(parseAdr).filter(Boolean) as AdrEntry[];

--- a/scripts/verify-doc-governance.ts
+++ b/scripts/verify-doc-governance.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env npx tsx
+/**
+ * Formal documentation governance checks.
+ *
+ * Goals:
+ * 1) Ensure index markers exist for auto-generated tables.
+ * 2) Ensure ADR files follow minimal metadata contract.
+ * 3) Ensure every ADR has a linked discussion log.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DOC_ROOT = join(__dirname, '..', 'doc');
+const ADR_DIR = join(DOC_ROOT, 'adr');
+const PITFALL_DIR = join(DOC_ROOT, 'pitfall');
+
+const START_MARKER = '<!-- INDEX:START -->';
+const END_MARKER = '<!-- INDEX:END -->';
+
+const errors: string[] = [];
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) errors.push(message);
+}
+
+function requireIndexMarkers(readmePath: string): void {
+  assert(existsSync(readmePath), `Missing README: ${readmePath}`);
+  if (!existsSync(readmePath)) return;
+
+  const content = readFileSync(readmePath, 'utf-8');
+  assert(
+    content.includes(START_MARKER) && content.includes(END_MARKER),
+    `Missing index markers in ${readmePath}`,
+  );
+}
+
+function verifyAdrFiles(): void {
+  if (!existsSync(ADR_DIR)) return;
+
+  const adrFiles = readdirSync(ADR_DIR).filter(
+    (name) => /^\d{3}-.*\.md$/.test(name) && !name.endsWith('.discussion.md'),
+  );
+
+  for (const file of adrFiles) {
+    const fullPath = join(ADR_DIR, file);
+    const content = readFileSync(fullPath, 'utf-8');
+
+    assert(/^#\s+ADR-\d+:\s+.+$/m.test(content), `${file}: missing ADR title line`);
+    assert(/^Status:\s*.+$/m.test(content), `${file}: missing Status field`);
+    assert(/^Date:\s*\d{4}-\d{2}-\d{2}$/m.test(content), `${file}: missing Date field (YYYY-MM-DD)`);
+
+    const discussion = content.match(
+      /^>\s*Discussion:\s*\[discussion log\]\(([^)]+\.discussion\.md)\)\s*$/mi,
+    );
+    assert(Boolean(discussion), `${file}: missing discussion link line`);
+    if (discussion?.[1]) {
+      const discussionPath = join(ADR_DIR, discussion[1]);
+      assert(existsSync(discussionPath), `${file}: linked discussion file not found (${discussion[1]})`);
+    }
+  }
+
+  const discussionFiles = readdirSync(ADR_DIR).filter((name) => name.endsWith('.discussion.md'));
+  for (const discussionFile of discussionFiles) {
+    const adrFile = discussionFile.replace('.discussion.md', '.md');
+    assert(adrFiles.includes(adrFile), `${discussionFile}: missing paired ADR file (${adrFile})`);
+  }
+}
+
+function main(): void {
+  requireIndexMarkers(join(ADR_DIR, 'README.md'));
+  requireIndexMarkers(join(PITFALL_DIR, 'README.md'));
+  verifyAdrFiles();
+
+  if (errors.length > 0) {
+    console.error('\n❌ Documentation governance checks failed:\n');
+    for (const err of errors) console.error(`- ${err}`);
+    process.exit(1);
+  }
+
+  console.log('✅ Documentation governance checks passed');
+  const adrCount = existsSync(ADR_DIR)
+    ? readdirSync(ADR_DIR).filter(
+        (name) => /^\d{3}-.*\.md$/.test(name) && !name.endsWith('.discussion.md'),
+      ).length
+    : 0;
+  console.log(`   ADR files checked: ${adrCount}`);
+  console.log('   Index marker checks: adr + pitfall');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a formal `doc:governance` gate (`gen:index` + `doc:check`) for consistent documentation validation
- add `scripts/verify-doc-governance.ts` to enforce ADR metadata and ADR↔discussion pairing
- harden ADR index generation to ignore `*.discussion.md` and keep markdownlint-safe table formatting

## Test plan
- [x] Run `pnpm doc:governance`
- [x] Confirm ADR README index excludes `*.discussion.md`
- [x] Confirm governance check validates discussion-link requirements
- [x] Verify lint diagnostics show no new errors for modified files

Resolves #1

Made with [Cursor](https://cursor.com)